### PR TITLE
Commit 20240903175600

### DIFF
--- a/ncom/client.py
+++ b/ncom/client.py
@@ -3,15 +3,39 @@ from client_utils import *
 
 __logger = Logger(is_server=False)
 
-cus = [ClientUtil(__logger) for _ in range(20)]  # 20 connections
+#   -------------------------------------------------------------------------
+#   Uncomment the following to check for the server's ability to respond to
+#   multiple concurrent connections.
+#   -------------------------------------------------------------------------
+# cus = [ClientUtil(__logger) for _ in range(20)]  # 20 connections
+#
+# for cu in cus:
+#     cu.establish_session()
+#     cu.send_message('ECC GET-P-RCD', False, True)
+#
+# for i, cu in enumerate(cus):
+#     if (recv := cu.get_response(Header.NGHeaderItems.header_length()))[0]:
+#         print(i, cu.verify(parsed := cu.parse(recv[-1])), parsed)
+#     else:
+#         print(i, 'No response.')
+#    cu.close_session()
+#
+#   -------------------------------------------------------------------------
 
-for cu in cus:
-    cu.establish_session()
-    cu.send_message('ECC GET-P-RCD', False, True)
+client = ClientUtil(__logger)  # Create a client
+client.establish_session()   # Establish connection w/ NG server
 
-for i, cu in enumerate(cus):
-    print(i, cu.get_response(1024))
-    cu.close_session()
+if client.connection_established:
+    client.send_message(b'ECC GET-P-RCD', False, True)
+    recv_s, recv_d = client.get_response(1024)
+    if recv_s:
+        parsed = client.parse(recv_d)
+        print('', (tL := client.verify(parsed))[-1], parsed, recv_d, sep='\n\t')
+
+    else:
+        __logger.log(LoggingLevel.ERROR, 'NGClient', 'Could not establish connection w/ server; ABORT (2).')
+else:
+    __logger.log(LoggingLevel.ERROR, 'NGClient', 'Could not establish connection w/ server; ABORT.')
 
 __logger.stop()
 sys.exit(0)

--- a/ncom/com.CHANGELOG
+++ b/ncom/com.CHANGELOG
@@ -57,6 +57,22 @@ Bugfix:
 Bugfix:
 * Added a missing `i += 1` line in `_con_conn` which had previously led to a frozen server upon the second request.
 
+09/03/2024
+* Ability to filter out forms from client ECC requests.
+* Added a shutdown tasks "plugin" for servers.
+* Added MAX_LOOP_ITER and MAX_LOOP_TIME settings/config to ncom.config
+    - Implemented in NG server; will not be implemented in LEGACY server.
+    - Need to "register" a loop to add protections.
+    - Protects from cases that stall an application.
+    - Reconfigured ng.com_hist_key to be a "protected" loop.
+* Modified code in `client.py` to only send 1 request. Old code left but commented-out for testing.
+* Added ClientUtils.verify to check transmissions and decypher messages.
+    - Bugfix: added protections to ClientUtils.parse and ClientUtils.verify to make sure that messages w/ no header (usually errors) do not cause problems.
+* Added debug information to EXT_HEADER loader.
+* Removed the '<end>' string appended to messages sent by `ng._con_conn`.
+* Changed Structs.Transmission to accommodate `NoneType` headers.
+
+
 
 TODO:
 * Add a system to check that repeat commands are not issued w/ the same TX time (to make sure that transmissions cannot be cloned)

--- a/ncom/ncom.config
+++ b/ncom/ncom.config
@@ -20,3 +20,7 @@
 <BOOL>LG_LOG_WARN               = 1
 <BOOL>LG_LOG_INFO               = 1
 <BOOL>LG_LOG_DEBUG              = 1
+
+# Loops
+<FLOAT>LOOP_MAX_TIME_MIN        = 1.0
+<INT>LOOP_MAX_ITER              = 999999

--- a/ncom/sc_data/appinfo.py
+++ b/ncom/sc_data/appinfo.py
@@ -21,6 +21,9 @@ class AppInfo(Constants):
     LG_LOG_INFO: bool
     LG_LOG_DEBUG: bool
 
+    LOOP_MAX_TIME_MIN: float
+    LOOP_MAX_ITER:     int
+
     # Additional Items
     APP_DATA_PATH:              str
 

--- a/ncom/sc_data/header.py
+++ b/ncom/sc_data/header.py
@@ -214,10 +214,16 @@ class _NGHeader:
         exh_delim = b'<EXH_DELIM>'
         exh_null = b'<EXH_NO_DATA>'
 
-        return ExtendedHeader(*[
+        args = [
             d.decode() if d != exh_null else None
             for d in __bytes.split(exh_delim)
-        ])
+        ]
+
+        try:
+            return ExtendedHeader(*args)
+        except Exception as E:
+            print(args)
+            raise E
 
     @staticmethod
     def create_bytes(__ngh: NGHeader, __hash: str) -> bytes:

--- a/ncom/sc_data/settings.py
+++ b/ncom/sc_data/settings.py
@@ -18,6 +18,10 @@ class Settings(Constants):
     LG_LOG_INFO:                        bool
     LG_LOG_DEBUG:                       bool
 
+    # Loop Settings
+    LOOP_MAX_TIME_MIN:                  float
+    LOOP_MAX_ITER:                      int
+
 
 SETTINGS = Settings(
     SRVC_CLT_PROMPT_IP=APPINFO.SRVC_CLT_PROMPT_IP,
@@ -29,5 +33,7 @@ SETTINGS = Settings(
     LG_LOG_WARN=APPINFO.LG_LOG_WARN,
     LG_LOG_INFO=APPINFO.LG_LOG_INFO,
     LG_LOG_DEBUG=APPINFO.LG_LOG_DEBUG,
+    LOOP_MAX_TIME_MIN=APPINFO.LOOP_MAX_TIME_MIN,
+    LOOP_MAX_ITER=APPINFO.LOOP_MAX_ITER
 )
 

--- a/ncom/sc_data/struct.py
+++ b/ncom/sc_data/struct.py
@@ -69,7 +69,7 @@ class ExtendedHeader:           # Only used by clients.
 
 @dataclass
 class Transmission:
-    hdr:    NGHeader | LegacyHeader
+    hdr:    NGHeader | LegacyHeader | None
     exh:    ExtendedHeader | None       # Servers do not send an EXH
     chk:    str                         # Message hash
     msg:    bytes

--- a/ncom/sc_server/_template.py
+++ b/ncom/sc_server/_template.py
@@ -59,6 +59,8 @@ class __fc_server__:
         self.__cost_timer__ = AppInfo.APPINFO.COST_TIMER
         self.__attr__ = ()
 
+        self.__shutdown_tasks__ = []
+
         self._on_init()
 
     @property
@@ -84,6 +86,13 @@ class __fc_server__:
         self.sf_execute(self.__cost_task__.cancel)
         self.sf_execute(self._close_all_sockets)
         self.sf_execute(self._shutdown)
+
+        for task in self.__shutdown_tasks__:
+            self.logger.log(
+                LoggingLevel.INFO,
+                'TemplateServer',
+                f'PLUGINS.EXIT; SFTask<{task}> -> {self.sf_execute(task)}'
+            )
 
     def _close_all_sockets(self) -> None:
         for c_name, (thread, conn, addr) in self.__connectors__.items():


### PR DESCRIPTION
* Ability to filter out forms from client ECC requests.
* Added a shutdown tasks "plugin" for servers.
* Added MAX_LOOP_ITER and MAX_LOOP_TIME settings/config to ncom.config - Implemented in NG server; will not be implemented in LEGACY server. - Need to "register" a loop to add protections. - Protects from cases that stall an application. - Reconfigured ng.com_hist_key to be a "protected" loop.
* Modified code in `client.py` to only send 1 request. Old code left but commented-out for testing.
* Added ClientUtils.verify to check transmissions and decypher messages. - Bugfix: added protections to ClientUtils.parse and ClientUtils.verify to make sure that messages w/ no header (usually errors) do not cause problems.
* Added debug information to EXT_HEADER loader.
* Removed the '<end>' string appended to messages sent by `ng._con_conn`.
* Changed Structs.Transmission to accommodate `NoneType` headers.